### PR TITLE
Fix `author_last_change` aka Author's reply date

### DIFF
--- a/controllers/user.py
+++ b/controllers/user.py
@@ -1875,8 +1875,6 @@ def edit_reply():
         redirect(URL(c="user", f="recommendations", vars=dict(articleId=art.id), user_signature=True, anchor="author-reply"))
     elif form.errors:
         response.flash = T("Form has errors", lazy=False)
-    recomm.author_last_change = request.now
-    recomm.update_record()
     return dict(
         pageHelp=getHelp(request, auth, db, "#UserEditReply"),
         # myBackButton = common_small_html.mkBackButton(),

--- a/models/db.py
+++ b/models/db.py
@@ -864,7 +864,7 @@ db.define_table(
     ),
     Field("recommendation_timestamp", type="datetime", default=request.now, label=T("Recommendation start"), writable=False, requires=IS_NOT_EMPTY()),
     Field("last_change", type="datetime", default=request.now, label=T("Last change"), writable=False),
-    Field("author_last_change", type="datetime", default=request.now, label=T("Author's last change"), writable=False),
+    Field("author_last_change", type="datetime", label=T("Author's last change"), writable=False),
     Field("is_closed", type="boolean", label=T("Closed"), default=False),
     Field("no_conflict_of_interest", type="boolean", label=T("I/we declare that I/we have no conflict of interest with the authors or the content of the article")),
     Field("reply", type="text", length=2097152, label=T("Author's Reply"), default=""),

--- a/models/db.py
+++ b/models/db.py
@@ -864,7 +864,6 @@ db.define_table(
     ),
     Field("recommendation_timestamp", type="datetime", default=request.now, label=T("Recommendation start"), writable=False, requires=IS_NOT_EMPTY()),
     Field("last_change", type="datetime", default=request.now, label=T("Last change"), writable=False),
-    Field("author_last_change", type="datetime", label=T("Author's last change"), writable=False),
     Field("is_closed", type="boolean", label=T("Closed"), default=False),
     Field("no_conflict_of_interest", type="boolean", label=T("I/we declare that I/we have no conflict of interest with the authors or the content of the article")),
     Field("reply", type="text", length=2097152, label=T("Author's Reply"), default=""),

--- a/modules/app_components/ongoing_recommendation.py
+++ b/modules/app_components/ongoing_recommendation.py
@@ -213,7 +213,11 @@ def getRecommendationProcessForSubmitter(auth, db, response, art, printable, sch
             managerDecisionDoneClass = "step-default"
             authorsReplyClass = "step-default"
             recommDate = recomm.last_change.strftime("%d %B %Y")
-            authorsReplyDate = (recomm.author_last_change or recomm.last_change).strftime("%d %B %Y")
+            if roundNumber < totalRecomm:
+                nextRound = recomms[roundNumber]
+                authorsReplyDate = nextRound.recommendation_timestamp.strftime(DEFAULT_DATE_FORMAT)
+            else:
+                authorsReplyDate = None # current round
 
             recommenderName = common_small_html.getRecommAndReviewAuthors(
                 auth, db, recomm=recomm, with_reviewers=False, linked=not (printable), host=host, port=port, scheme=scheme
@@ -436,7 +440,9 @@ def getRecommendationProcess(auth, db, response, art, printable=False, quiet=Tru
             )
 
         if (recomm.reply is not None and len(recomm.reply) > 0) or recomm.reply_pdf is not None or recomm.track_change is not None:
-            authorsReplyDate = (recomm.author_last_change or recomm.last_change).strftime(DEFAULT_DATE_FORMAT+ " %H:%M")
+            authorsReplyDate = nextRound.recommendation_timestamp.strftime(DEFAULT_DATE_FORMAT+ " %H:%M") \
+                    if roundNb < nbRecomms else None
+        nextRound = recomm # iteration is most recent first; last round (final reco) has no author's reply
             
         editAuthorsReplyLink = None
         if (art.user_id == auth.user_id) and (art.status == "Awaiting revision") and not (printable) and (iRecomm == 1):

--- a/modules/app_components/public_recommendation.py
+++ b/modules/app_components/public_recommendation.py
@@ -300,7 +300,9 @@ def getPublicReviewRoundsHtml(auth, db, response, articleId):
                 _style="font-weight: bold; margin-bottom: 5px; display:block",
             )
         if (recomm.reply is not None and len(recomm.reply) > 0) or recomm.reply_pdf is not None or recomm.track_change is not None:
-            authorsReplyDate = (recomm.author_last_change or recomm.last_change).strftime(DEFAULT_DATE_FORMAT)
+            authorsReplyDate = nextRound.recommendation_timestamp.strftime(DEFAULT_DATE_FORMAT) \
+                if not isLastRecomm else None
+        nextRound = recomm # iteration is last first; last round (final reco) has no author's reply
 
         recommendationPdfLink = None
         if recomm.recommender_file:

--- a/sql_dumps/pci_evolbiol_test.sql
+++ b/sql_dumps/pci_evolbiol_test.sql
@@ -2914,8 +2914,9 @@ ALTER TABLE "t_press_reviews"
 ADD COLUMN IF NOT EXISTS  contributor_details character varying(512);
 
 -- 2022-06-15 updates/t_recomm_new_field.sql
+-- 2022-09-26 fix default value = NULL
 ALTER TABLE "t_recommendations"
-ADD COLUMN IF NOT EXISTS author_last_change timestamp without time zone DEFAULT statement_timestamp();
+ADD COLUMN IF NOT EXISTS author_last_change timestamp without time zone;
 
 -- 2022-06-16 updates/alter_data_scripts.sql
 ALTER TABLE "t_articles"

--- a/sql_dumps/pci_evolbiol_test.sql
+++ b/sql_dumps/pci_evolbiol_test.sql
@@ -2913,11 +2913,6 @@ ADD COLUMN IF NOT EXISTS  recommender_details character varying(512);
 ALTER TABLE "t_press_reviews"
 ADD COLUMN IF NOT EXISTS  contributor_details character varying(512);
 
--- 2022-06-15 updates/t_recomm_new_field.sql
--- 2022-09-26 fix default value = NULL
-ALTER TABLE "t_recommendations"
-ADD COLUMN IF NOT EXISTS author_last_change timestamp without time zone;
-
 -- 2022-06-16 updates/alter_data_scripts.sql
 ALTER TABLE "t_articles"
 ALTER COLUMN  data_doi TYPE text,

--- a/updates/drop-author_last_change.sql
+++ b/updates/drop-author_last_change.sql
@@ -1,0 +1,1 @@
+ALTER TABLE t_recommendations DROP author_last_change;

--- a/updates/drop-default-author_last_change.sql
+++ b/updates/drop-default-author_last_change.sql
@@ -1,2 +1,0 @@
-ALTER TABLE t_recommendations ALTER author_last_change DROP DEFAULT;
-UPDATE t_recommendations SET author_last_change = NULL;

--- a/updates/drop-default-author_last_change.sql
+++ b/updates/drop-default-author_last_change.sql
@@ -1,1 +1,2 @@
 ALTER TABLE t_recommendations ALTER author_last_change DROP DEFAULT;
+UPDATE t_recommendations SET author_last_change = NULL;

--- a/updates/drop-default-author_last_change.sql
+++ b/updates/drop-default-author_last_change.sql
@@ -1,0 +1,1 @@
+ALTER TABLE t_recommendations ALTER author_last_change DROP DEFAULT;


### PR DESCRIPTION
The original intent was to fix the default value for `author_last_change` (see first 2 commits).

This eventually morphed into _plain removal_ of `author_last_change`, when it appeared that "next round creation date" was the right date to display as "author's reply date".