### PR TITLE
Remove version from public display

### DIFF
--- a/modules/app_components/public_recommendation.py
+++ b/modules/app_components/public_recommendation.py
@@ -52,6 +52,10 @@ def getArticleAndFinalRecommendation(auth, db, response, art, finalRecomm, print
 
     articleInfosCard = article_components.getArticleInfosCard(auth, db, response, art, printable, with_cover_letter=False, submittedBy=False)
 
+    html = TAG(articleInfosCard)
+    html.elements('span[id=version]', replace=None)
+    articleInfosCard = XML(html)
+
     headerContent.update([("articleInfosCard", articleInfosCard)])
 
     isStage2 = art.art_stage_1_id is not None

--- a/views/components/article_infos_card.html
+++ b/views/components/article_infos_card.html
@@ -26,7 +26,7 @@
         <span class="pci2-article-infos">{{=articleAuthor}}</span>
         <span class="pci2-article-infos">{{=articleSource}}</span>
         <span class="pci2-article-infos">{{=articleDoi}}</span>
-        <span class="pci2-article-infos">{{=articleVersion}}</span>
+        <span class="pci2-article-infos" id="version">{{=articleVersion}}</span>
         {{if 'articleKeywords' in locals():}}
         <span class="pci2-article-infos">{{=articleKeywords}}</span>
         {{pass}}


### PR DESCRIPTION
remove version info span from public recommendation page

This implementation does a touch-up of the article info-card's html tree. An alternative implementation would have been to add `with_version=False` as parameter to `getArticleInfosCard()`.

Note: original implementation (63ca2298a536e934bade9a01209166d98c6788ac) removed version info via BeautifulSoup:
- add new python module
- use bs4 to parse and edit XML
