### PR TITLE
Bigger article thumbnails

### DIFF
--- a/controllers/admin_actions.py
+++ b/controllers/admin_actions.py
@@ -48,7 +48,7 @@ def resizeAllUserImages():
 @auth.requires(auth.has_membership(role="administrator") or auth.has_membership(role="developer"))
 def resizeAllArticleImages():
     for articleId in db(db.t_articles.uploaded_picture != None).select(db.t_articles.id):
-        common_small_html.makeArticleThumbnail(auth, db, articleId, size=(150, 150))
+        common_small_html.makeArticleThumbnail(auth, db, articleId, size=db.article_thumb_size)
     redirect(request.env.http_referer)
 
 

--- a/models/db.py
+++ b/models/db.py
@@ -838,7 +838,7 @@ def newArticle(s, articleId):
     return None
 
 
-db.article_thumb_size = (150,150)
+db.article_thumb_size = (500,500)
 
 def insArticleThumb(f, i):
     common_small_html.makeArticleThumbnail(auth, db, i, size=db.article_thumb_size)

--- a/models/db.py
+++ b/models/db.py
@@ -838,14 +838,16 @@ def newArticle(s, articleId):
     return None
 
 
+db.article_thumb_size = (150,150)
+
 def insArticleThumb(f, i):
-    common_small_html.makeArticleThumbnail(auth, db, i, size=(150, 150))
+    common_small_html.makeArticleThumbnail(auth, db, i, size=db.article_thumb_size)
     return None
 
 
 def updArticleThumb(s, f):
     o = s.select().first()
-    common_small_html.makeArticleThumbnail(auth, db, o.id, size=(150, 150))
+    common_small_html.makeArticleThumbnail(auth, db, o.id, size=db.article_thumb_size)
     return None
 
 


### PR DESCRIPTION
- up articles thumbnail picture size
- if perf issue, see:
   https://github.com/web2py/web2py/issues/2023

this is a «cosmetic» change that caters for the storage of better quality thumbnails for articles ; the code currently performs image size reduction to 150x150 prior to storing in a blob in the db ; we could store bigger images.