### PR TITLE
Recommenders can Opt in/out of being cc'ed on emails

### DIFF
--- a/controllers/admin.py
+++ b/controllers/admin.py
@@ -65,7 +65,9 @@ def list_users():
     if len(request.args) == 1: # list/search view (i.e. not edit form)
         db.auth_user.thematics.requires = IS_IN_DB(db, db.t_thematics.keyword, "%(keyword)s", zero=None)
         db.auth_user.thematics.type = "string" # for advanced search dd, vs "list:string" in edit form
-
+    if not pciRRactivated:
+        db.auth_user.email_options.readable = False
+        db.auth_user.email_options.writable = False
     fields = [
         db.auth_user.id,
         db.auth_user.registration_key,

--- a/controllers/admin.py
+++ b/controllers/admin.py
@@ -65,9 +65,15 @@ def list_users():
     if len(request.args) == 1: # list/search view (i.e. not edit form)
         db.auth_user.thematics.requires = IS_IN_DB(db, db.t_thematics.keyword, "%(keyword)s", zero=None)
         db.auth_user.thematics.type = "string" # for advanced search dd, vs "list:string" in edit form
-    if not pciRRactivated:
-        db.auth_user.email_options.readable = False
-        db.auth_user.email_options.writable = False
+
+    if 'edit' in request.raw_args:
+        user_id = [val for val in request.args if val.isdigit()]
+        auth_query = db((db.auth_membership.user_id == next(iter(user_id), None)) & (db.auth_membership.group_id == db.auth_group._id) & (db.auth_group.role == "recommender")).select()
+
+        if not auth_query:
+            db.auth_user.email_options.readable = False
+            db.auth_user.email_options.writable = False
+            
     fields = [
         db.auth_user.id,
         db.auth_user.registration_key,

--- a/controllers/default.py
+++ b/controllers/default.py
@@ -263,7 +263,7 @@ def user():
             customText = getText(request, auth, db, "#ProfileText")
             myBottomText = getText(request, auth, db, "#ProfileBottomText")
             form.element(_type="submit")["_class"] = "btn btn-success"
-            if not pciRRactivated:
+            if not (auth.has_membership(role="recommender") and pciRRactivated):
                 form.element("#auth_user_email_options__row")["_style"] = "display: none;"
             if suite:
                 auth.settings.profile_next = suite

--- a/controllers/default.py
+++ b/controllers/default.py
@@ -263,6 +263,8 @@ def user():
             customText = getText(request, auth, db, "#ProfileText")
             myBottomText = getText(request, auth, db, "#ProfileBottomText")
             form.element(_type="submit")["_class"] = "btn btn-success"
+            if not pciRRactivated:
+                form.element("#auth_user_email_options__row")["_style"] = "display: none;"
             if suite:
                 auth.settings.profile_next = suite
 

--- a/controllers/recommender.py
+++ b/controllers/recommender.py
@@ -1381,10 +1381,11 @@ def send_review_cancellation():
     replyto_address = "%s, %s" % (replyto.email, myconf.take("contacts.managers"))
     default_subject = emailing.patch_email_subject(default_subject, recomm.article_id)
     default_cc = '%s, %s'%(replyto.email, contact)
+    ccAddresses = ",".join(emailing_tools.exempt_addresses(db, default_cc.split(","), hashtag_template))
 
     form = SQLFORM.factory(
         Field("replyto", label=T("Reply-to"), type="string", length=250, default=replyto_address, writable=False),
-        Field.CC(default=default_cc),
+        Field.CC(default=ccAddresses),
         Field(
             "reviewer_email",
             label=T("Reviewer email address"),
@@ -1466,8 +1467,8 @@ def send_reviewer_generic_mail():
     contact = myconf.take("contacts.managers")
 
     sender_email = db(db.auth_user.id == auth.user_id).select().last().email
-
-    mail_template = emailing_tools.getMailTemplateHashtag(db, "#ReviewerGenericMail")
+    hashtag_template = "#ReviewerGenericMail"
+    mail_template = emailing_tools.getMailTemplateHashtag(db, hashtag_template)
 
     # template variables, along with all other locals()
     destPerson = common_small_html.mkUser(auth, db, review.reviewer_id)
@@ -1486,10 +1487,11 @@ def send_reviewer_generic_mail():
 
     replyTo = ", ".join([replyto.email, contact])
     default_cc = '%s, %s'%(sender_email, contact)
+    ccAddresses = ",".join(emailing_tools.exempt_addresses(db, default_cc.split(","), hashtag_template))
 
     form = SQLFORM.factory(
         Field("reviewer_email", label=T("Reviewer email address"), type="string", length=250, requires=req_is_email, default=reviewer.email, writable=False),
-        Field.CC(default=default_cc),
+        Field.CC(default=ccAddresses),
         Field("replyto", label=T("Reply-to"), type="string", length=250, default=replyTo, writable=False),
         Field("subject", label=T("Subject"), type="string", length=250, default=default_subject, required=True),
         Field("message", label=T("Message"), type="text", default=default_message, required=True),
@@ -1631,11 +1633,12 @@ def email_for_registered_reviewer():
     
     replyto_address = "%s, %s" % (sender.email, myconf.take("contacts.managers"))
     default_cc = '%s, %s'%(sender.email, myconf.take("contacts.managers"))
+    ccAddresses = ",".join(emailing_tools.exempt_addresses(db, default_cc.split(","), hashtag_template))
 
     form = SQLFORM.factory(
         Field("review_duration", type="string", label=T("Review duration"), **get_review_duration_options(article)),
         Field("replyto", label=T("Reply-to"), type="string", length=250, default=replyto_address, writable=False),
-        Field.CC(default_cc),
+        Field.CC(ccAddresses),
         Field(
             "reviewer_email",
             label=T("Reviewer e-mail address"),
@@ -1776,11 +1779,12 @@ def email_for_new_reviewer():
 
     replyto_address = "%s, %s" % (sender.email, myconf.take("contacts.managers"))
     default_cc = '%s, %s'%(sender.email, myconf.take('contacts.managers'))
+    ccAddresses = ",".join(emailing_tools.exempt_addresses(db, default_cc.split(","), hashtag_template))
 
     form = SQLFORM.factory(
         Field("review_duration", type="string", label=T("Review duration"), **get_review_duration_options(article)),
         Field("replyto", label=T("Reply-to"), type="string", length=250, default=replyto_address, writable=False),
-        Field.CC(default=default_cc),
+        Field.CC(default=ccAddresses),
         Field("reviewer_first_name", label=T("Reviewer first name"), type="string", length=250, requires=IS_NOT_EMPTY()),
         Field("reviewer_last_name", label=T("Reviewer last name"), type="string", length=250, requires=IS_NOT_EMPTY()),
         Field("reviewer_email", label=T("Reviewer e-mail address"), type="string", length=250, requires=IS_NOT_EMPTY()),

--- a/languages/default_RR.py
+++ b/languages/default_RR.py
@@ -491,6 +491,7 @@
     "Ongoing reviewers": "Ongoing reviewers",
     "Online examples": "Online examples",
     "Open to reviewers": "Open to reviewers",
+    "Opt in/out of being cc'ed": "Opt in/out of being cc'ed on emails for submissions you handle as a Recommender (note that you will always be cc'ed if an author or reviewer is overdue on their task)",
     "Origin": "Origin",
     "or import from csv file": "or import from csv file",
     " or ": " or ",

--- a/languages/default_RR.py
+++ b/languages/default_RR.py
@@ -491,7 +491,7 @@
     "Ongoing reviewers": "Ongoing reviewers",
     "Online examples": "Online examples",
     "Open to reviewers": "Open to reviewers",
-    "Opt in/out of being cc'ed": "Opt in/out of being cc'ed on emails for submissions you handle as a Recommender (note that you will always be cc'ed if an author or reviewer is overdue on their task)",
+    "Opt in/out of being cc'ed": "Opt in to being cc'ed on emails for submissions you handle as a Recommender (note that you will always be cc'ed if an author or reviewer is overdue on their task)",
     "Origin": "Origin",
     "or import from csv file": "or import from csv file",
     " or ": " or ",

--- a/languages/default_base.py
+++ b/languages/default_base.py
@@ -487,7 +487,7 @@
     "Ongoing reviewers": "Ongoing reviewers",
     "Online examples": "Online examples",
     "Open to reviewers": "Open to reviewers",
-    "Opt in/out of being cc'ed": "Opt in/out of being cc'ed on emails for submissions you handle as a Recommender (note that you will always be cc'ed if an author or reviewer is overdue on their task)",
+    "Opt in/out of being cc'ed": "Opt in to being cc'ed on emails for submissions you handle as a Recommender (note that you will always be cc'ed if an author or reviewer is overdue on their task)",
     "Origin": "Origin",
     "or import from csv file": "or import from csv file",
     " or ": " or ",

--- a/languages/default_base.py
+++ b/languages/default_base.py
@@ -487,6 +487,7 @@
     "Ongoing reviewers": "Ongoing reviewers",
     "Online examples": "Online examples",
     "Open to reviewers": "Open to reviewers",
+    "Opt in/out of being cc'ed": "Opt in/out of being cc'ed on emails for submissions you handle as a Recommender (note that you will always be cc'ed if an author or reviewer is overdue on their task)",
     "Origin": "Origin",
     "or import from csv file": "or import from csv file",
     " or ": " or ",

--- a/models/db.py
+++ b/models/db.py
@@ -426,6 +426,10 @@ auth.settings.extra_fields["auth_user"] = [
     ),
     Field("cv", type="text", length=2097152, label=SPAN(T("Areas of expertise")) + SPAN(" * ", _style="color:red;"), requires=IS_NOT_EMPTY()),
     Field("keywords", type="string", length=1024, label=SPAN(T("Keywords")) + SPAN(" * ", _style="color:red;"), requires=IS_NOT_EMPTY()),
+    Field("email_options", type="list:string", label=SPAN(T("Opt in/out of being cc'ed")), 
+          requires=[IS_EMPTY_OR(IS_IN_SET(("Email to authors", "Email to reviewers"), multiple=True))], 
+          widget=SQLFORM.widgets.checkboxes.widget,
+    ),
     Field("website", type="string", length=4096, label=SPAN(T("Link to your website, profile page, google scholar profile or any other professional website")) + SPAN(" * ", _style="color:red;"), requires=IS_NOT_EMPTY()),
     Field(
         "alerts",

--- a/models/db.py
+++ b/models/db.py
@@ -143,6 +143,7 @@ upload_file_contraints = lambda extensions=allowed_upload_filetypes: [
         IS_EMPTY_OR(IS_FILE(extension=extensions)),
 ]
 
+email_options = {"Email to authors", "Email to reviewers"}
 # -------------------------------------------------------------------------
 # by default give a view/generic.extension to all actions from localhost
 # none otherwise. a pattern can be 'controller/function.extension'
@@ -427,8 +428,8 @@ auth.settings.extra_fields["auth_user"] = [
     Field("cv", type="text", length=2097152, label=SPAN(T("Areas of expertise")) + SPAN(" * ", _style="color:red;"), requires=IS_NOT_EMPTY()),
     Field("keywords", type="string", length=1024, label=SPAN(T("Keywords")) + SPAN(" * ", _style="color:red;"), requires=IS_NOT_EMPTY()),
     Field("email_options", type="list:string", label=SPAN(T("Opt in/out of being cc'ed")), 
-          requires=[IS_EMPTY_OR(IS_IN_SET(("Email to authors", "Email to reviewers"), multiple=True))], 
-          widget=SQLFORM.widgets.checkboxes.widget,
+          requires=[IS_EMPTY_OR(IS_IN_SET(email_options, multiple=True))], 
+          widget=SQLFORM.widgets.checkboxes.widget, default=list(email_options)
     ),
     Field("website", type="string", length=4096, label=SPAN(T("Link to your website, profile page, google scholar profile or any other professional website")) + SPAN(" * ", _style="color:red;"), requires=IS_NOT_EMPTY()),
     Field(

--- a/modules/app_modules/emailing_tools.py
+++ b/modules/app_modules/emailing_tools.py
@@ -462,6 +462,9 @@ def insertMailInQueue(
         alternative_subject=alternative_subject,
         alternative_content=alternative_content,
     )
+    ccAddresses = mail_vars.get("ccAddresses") or None
+    if pciRRactivated and ccAddresses:
+        ccAddresses = exempt_addresses(db, ccAddresses, hashtag_template)
 
     if alternative_subject:
         subject = alternative_subject
@@ -472,7 +475,7 @@ def insertMailInQueue(
 
     return db.mail_queue.insert(
         dest_mail_address=mail_vars["destAddress"],
-        cc_mail_addresses=mail_vars.get("ccAddresses"),
+        cc_mail_addresses=ccAddresses,
         replyto_addresses=mail_vars.get("replytoAddresses"),
         bcc_mail_addresses=mail_vars.get("bccAddresses"),
         mail_subject=subject,
@@ -504,12 +507,10 @@ def insertReminderMailInQueue(
 
     reminder = getReminder(hashtag_template, db.t_reviews[review_id])
 
-    ccAddresses = None
-    replytoAddresses = None
-    if "ccAddresses" in mail_vars:
-        ccAddresses = mail_vars["ccAddresses"]
-    if "replytoAddresses" in mail_vars:
-        replytoAddresses = mail_vars["replytoAddresses"]
+    ccAddresses = mail_vars.get("ccAddresses") or None
+    replytoAddresses = mail_vars.get("replytoAddresses") or None
+    if pciRRactivated and ccAddresses and "OverDue" not in hashtag_template:
+            ccAddresses = exempt_addresses(db, ccAddresses, hashtag_template)
 
     if reminder:
         elapsed_days = reminder["elapsed_days"][0]

--- a/modules/app_modules/emailing_tools.py
+++ b/modules/app_modules/emailing_tools.py
@@ -284,6 +284,21 @@ def list_addresses(addresses):
                 if addresses else []
 
 #######################################################################################################################################################################
+def exempt_addresses(db, addresses, hashtag_template):
+    for address in addresses:
+        user_id = db(db.auth_user.email == address).select(db.auth_user.id).last()
+        if user_id:
+            user = db.auth_user[user_id.id]
+            email_options = ",".join(user.email_options)
+            if user.email_options == []:
+                addresses.remove(address)
+            elif "authors" not in email_options and "Submitter" in hashtag_template:
+                addresses.remove(address)
+            elif "reviewers"  not in  email_options and ("Reviewer" in hashtag_template or "Review" in hashtag_template):
+                addresses.remove(address)
+    return addresses
+
+#######################################################################################################################################################################
 def clean_addresses(dirty_string_adresses):
     '''
     creates a string of clean mail addresses, divided by comma

--- a/modules/app_modules/emailing_tools.py
+++ b/modules/app_modules/emailing_tools.py
@@ -290,7 +290,9 @@ def exempt_addresses(db, addresses, hashtag_template):
         if user_id:
             user = db.auth_user[user_id.id]
             email_options = ",".join(user.email_options)
-            if user.email_options == []:
+            if hashtag_template == "#ReminderSubmitterScheduledSubmissionDue":
+                continue
+            elif user.email_options == []:
                 addresses.remove(address)
             elif "authors" not in email_options and "Submitter" in hashtag_template:
                 addresses.remove(address)

--- a/sql_dumps/pci_evolbiol_test.sql
+++ b/sql_dumps/pci_evolbiol_test.sql
@@ -3097,4 +3097,4 @@ ADD COLUMN IF NOT EXISTS due_date TIMESTAMP;
 
 --2023-09-13 updates/email_options.sql
 ALTER TABLE "auth_user" 
-ADD COLUMN "email_options" character varying(1024) DEFAULT '||'::character varying;
+ADD COLUMN "email_options" character varying(1024) DEFAULT '|Email to reviewers|Email to authors|'::character varying;

--- a/sql_dumps/pci_evolbiol_test.sql
+++ b/sql_dumps/pci_evolbiol_test.sql
@@ -3096,5 +3096,5 @@ ALTER TABLE "t_reviews"
 ADD COLUMN IF NOT EXISTS due_date TIMESTAMP;
 
 --2023-09-13 updates/email_options.sql
-ALTER TABLE 'auth_user' 
-ADD COLUMN 'email_options' character varying(1024) DEFAULT '||'::character varying;
+ALTER TABLE "auth_user" 
+ADD COLUMN "email_options" character varying(1024) DEFAULT '||'::character varying;

--- a/sql_dumps/pci_evolbiol_test.sql
+++ b/sql_dumps/pci_evolbiol_test.sql
@@ -3091,5 +3091,10 @@ ALTER COLUMN  dest_mail_address TYPE text;
 ALTER TABLE "mail_queue" 
 ADD COLUMN IF NOT EXISTS sender_name varchar(256);
 
+-- 2023-10-11 updates/due_date_review.sql
 ALTER TABLE "t_reviews"
 ADD COLUMN IF NOT EXISTS due_date TIMESTAMP;
+
+--2023-09-13 updates/email_options.sql
+ALTER TABLE 'auth_user' 
+ADD COLUMN 'email_options' character varying(1024) DEFAULT '||'::character varying;

--- a/static/css/components/web2py-forms.css
+++ b/static/css/components/web2py-forms.css
@@ -58,7 +58,8 @@ textarea.form-control {
 .checkbox #t_articles_picture_rights_ok__label,
 .checkbox #auth_user_remember_me__label,
 input[name=thematics]+label,
-input[name=alerts]+label {
+input[name=alerts]+label,
+input[name=email_options]+label {
     font-weight: normal;
 }
 

--- a/updates/email_options.sql
+++ b/updates/email_options.sql
@@ -1,0 +1,2 @@
+ALTER TABLE 'auth_user' 
+ADD COLUMN 'email_options' character varying(1024) DEFAULT '||'::character varying;

--- a/updates/email_options.sql
+++ b/updates/email_options.sql
@@ -1,2 +1,2 @@
-ALTER TABLE 'auth_user' 
-ADD COLUMN 'email_options' character varying(1024) DEFAULT '||'::character varying;
+ALTER TABLE "auth_user" 
+ADD COLUMN "email_options" character varying(1024) DEFAULT '||'::character varying;

--- a/updates/email_options.sql
+++ b/updates/email_options.sql
@@ -1,2 +1,2 @@
 ALTER TABLE "auth_user" 
-ADD COLUMN "email_options" character varying(1024) DEFAULT '||'::character varying;
+ADD COLUMN "email_options" character varying(1024) DEFAULT '|Email to reviewers|Email to authors|'::character varying;


### PR DESCRIPTION
Recommenders on the PCI-RR site can now choose to be CC'd in emails, by checking the box and unchecking if they do not want to be CC'd. This check box can be found in the lower half of the profile section.
