### PR TITLE
Use GET instead of HEAD in sign-posting get_link

### DIFF
--- a/controllers/coar_notify.py
+++ b/controllers/coar_notify.py
@@ -383,7 +383,7 @@ def guess_version(doi):
 
 
 def get_link(doi, **kv):
-    r = retry(requests.head, doi)
+    r = retry(requests.get, doi)
 
     for h in r.headers["link"].split(','):
         h = [v.strip() for v in h.split(';')]


### PR DESCRIPTION
Temporary workaround for DSpace 8.1 not honouring the HEAD requests.

This PR exists only to ease DSpace 8.1 integration testing.

Not needed in PCI prod, so long no DSpace 8.1 system with PCI workflow requirement is live in prod.

The fix to the DSpace code is expected in DSpace 8.2.